### PR TITLE
Fix case-insensitivity issue & write permissions

### DIFF
--- a/downloadlinuxpackage.sh
+++ b/downloadlinuxpackage.sh
@@ -10,6 +10,11 @@ else
         curl -O $ARCHIVE_URL
     fi
     unzip -P iagreetotheeula $ARCHIVE_NAME
+    # Workaround for case sensitivity issue where SC2 API returns
+    # lowercase name
+    if [ ! -e "StarCraftII/maps" ]; then
+        ln -r -s StarCraftII/Maps StarCraftII/maps
+    fi
     rm $ARCHIVE_NAME
 fi
 

--- a/template_container/Dockerfile
+++ b/template_container/Dockerfile
@@ -4,8 +4,6 @@ FROM ubuntu:17.10
 # Set the working directory to /app
 WORKDIR /app
 
-# Copy the current directory contents into the container at /app
-ADD . /app
 
 # Install needed packages
 RUN apt update -y
@@ -16,20 +14,26 @@ RUN pip3 install --trusted-host pypi.python.org sc2
 # RUN pip3 install -e python-sc2
 
 # Create users
-RUN useradd -ms /bin/bash user0
-RUN useradd -ms /bin/bash user1
+RUN useradd -ms /bin/bash user0 \
+	&& useradd -ms /bin/bash user1
 
-RUN ln -s /StarCraftII /home/user0/StarCraftII
-RUN ln -s /StarCraftII /home/user1/StarCraftII
+RUN groupadd -g 1500 sc2
 
-RUN chown -R user0 /app/repo0
-RUN chown -R user1 /app/repo1
+RUN gpasswd -a user0 sc2
+RUN gpasswd -a user1 sc2
 
-RUN chmod -R 700 /app/repo0
-RUN chmod -R 700 /app/repo1
+RUN ln -s /StarCraftII /home/user0/StarCraftII \
+	&& ln -s /StarCraftII /home/user1/StarCraftII
 
-RUN ln -s /app/repo0 /home/user0/repo
-RUN ln -s /app/repo1 /home/user1/repo
+# Copy the current directory contents into the container at /app
+ADD . /app
+
+RUN chown -R user0 /app/repo0 \
+	&& chown -R user1 /app/repo1 \
+	&& chmod -R 700 /app/repo0 \
+	&& chmod -R 700 /app/repo1 \
+	&& ln -s /app/repo0 /home/user0/repo \
+	&& ln -s /app/repo1 /home/user1/repo
 
 # Run startup.py when the container launches
-CMD python3 startup.py
+ENTRYPOINT python3 startup.py

--- a/template_container/startup.py
+++ b/template_container/startup.py
@@ -9,6 +9,11 @@ import sc2
 portconfig = sc2.portconfig.Portconfig()
 gameid = os.environ["sc2_match_id"]
 
+# Ensure SC2 gid and write permission
+os.chown("/replays", -1, 1500)
+os.chmod("/replays", 0o775)
+
+
 commands = [
     [
         "cd" # home directory


### PR DESCRIPTION
- SC2 API seems to return maps in lowercase for some reason (even though
it actually verifies the path?,
https://github.com/Dentosal/python-sc2/blob/f045e9883f9083ee94a2da4631a4a637c568a734/sc2/paths.py#L56)
- Add a group for SC2 runner and ensure write replay directory write
permissions
- Reorder Dockerfile a bit to take advantage of Docker's caching mechanism during building